### PR TITLE
Align dates on dex whitelabel page

### DIFF
--- a/src/pages/DexWhiteLabel.tsx
+++ b/src/pages/DexWhiteLabel.tsx
@@ -296,13 +296,13 @@ const DexWhiteLabel = () => {
           <div className="grid lg:grid-cols-4 gap-8">
             {integrationSteps.map((step, index) => (
               <div key={index} className="relative">
-                <Card className="p-6 bg-card/50 backdrop-blur-sm border-border/30 h-full">
+                <Card className="p-6 bg-card/50 backdrop-blur-sm border-border/30 h-full flex flex-col">
                   <div className="w-12 h-12 bg-gradient-primary rounded-xl flex items-center justify-center mb-4 mx-auto">
                     <span className="text-white font-bold text-lg">{step.step}</span>
                   </div>
                   <h3 className="text-lg font-semibold text-foreground mb-3 text-center">{step.title}</h3>
-                  <p className="text-sm text-muted-foreground mb-4 text-center">{step.description}</p>
-                  <div className="text-xs text-primary font-medium text-center bg-primary/10 rounded-full px-3 py-1">
+                  <p className="text-sm text-muted-foreground mb-4 text-center flex-grow">{step.description}</p>
+                  <div className="text-xs text-primary font-medium text-center bg-primary/10 rounded-full px-3 py-1 mt-auto">
                     {step.duration}
                   </div>
                 </Card>


### PR DESCRIPTION
Fixes date alignment in the Dex Whitelabel page's "Streamlined Integration Process" section to ensure dates are on the same row.

The previous layout caused dates to appear on different rows due to varying description lengths. By applying flexbox to the card, making the description flexible, and pushing the date badge to the bottom, all dates now align consistently, improving visual appeal.

---
<a href="https://cursor.com/background-agent?bcId=bc-240a883a-7d8a-451a-b6ba-a095388a932a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-240a883a-7d8a-451a-b6ba-a095388a932a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>